### PR TITLE
Update turn parsing to return player names

### DIFF
--- a/internal/test_cases/get_move_test_case.go
+++ b/internal/test_cases/get_move_test_case.go
@@ -26,7 +26,11 @@ type GetMoveTestCase struct {
 // Parsing FENs is a no-go for those test cases
 func getTurn(fenStr string) string {
 	parts := strings.Split(fenStr, " ")
-	return strings.TrimSpace(parts[1])
+	turn := strings.TrimSpace(parts[1])
+	if turn == "w" {
+		return "White"
+	}
+	return "Black"
 }
 
 func (tc *GetMoveTestCase) Run(stageHarness *test_case_harness.TestCaseHarness, logger *logger.Logger) error {

--- a/internal/test_cases/get_move_test_case.go
+++ b/internal/test_cases/get_move_test_case.go
@@ -28,9 +28,9 @@ func getTurn(fenStr string) string {
 	parts := strings.Split(fenStr, " ")
 	turn := strings.TrimSpace(parts[1])
 	if turn == "w" {
-		return "White"
+		return "white"
 	}
-	return "Black"
+	return "black"
 }
 
 func (tc *GetMoveTestCase) Run(stageHarness *test_case_harness.TestCaseHarness, logger *logger.Logger) error {


### PR DESCRIPTION
Modify the `getTurn` function to return "White" and "Black" instead of abbreviations for player turns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced turn representation to now display descriptive names ("white" or "black") instead of abbreviated forms, ensuring a clearer indication of turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->