### PR TITLE
Remove deprecated anti-cheat test case from tester definition

### DIFF
--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -16,10 +16,6 @@ var testerDefinition = tester_definition.TesterDefinition{
 			Slug:     "anti-cheat-2",
 			TestFunc: antiCheatDeps,
 		},
-		{
-			Slug:     "anti-cheat-3",
-			TestFunc: antiCheatFFI, // TODO: Remove FFI, might be a problem
-		},
 	},
 	ExecutableFileName: "your_program.sh",
 	TestCases: []tester_definition.TestCase{


### PR DESCRIPTION
Eliminate the outdated anti-cheat test case from the tester definition to streamline the testing process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined the internal testing process by removing an outdated anti-cheat test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->