### PR TITLE
Add file checking functionality and ENTRY.md template for tournament submissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ test_bot: build
 		{\"slug\":\"si0\",\"tester_log_prefix\":\"stage_1\",\"title\":\"Stage #2: Respond to move request\"}, \
 		{\"slug\":\"xt9\",\"tester_log_prefix\":\"stage_2\",\"title\":\"Stage #3: Respond with an opening\"}, \
 		{\"slug\":\"wd4\",\"tester_log_prefix\":\"stage_3\",\"title\":\"Stage #4: Bratko-Kopek test\"}, \
-		{\"slug\":\"zz5\",\"tester_log_prefix\":\"stage_4\",\"title\":\"Stage #5: Win at Chess\"} \
+		{\"slug\":\"zz5\",\"tester_log_prefix\":\"stage_4\",\"title\":\"Stage #5: Win at Chess\"}, \
+		{\"slug\":\"gd8\",\"tester_log_prefix\":\"stage_5\",\"title\":\"Stage #6: Make a move\"} \
 	]" \
 	$(shell pwd)/dist/main.out

--- a/internal/stage_1.go
+++ b/internal/stage_1.go
@@ -20,7 +20,7 @@ func test1(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err != nil {
 		return err
 	}
-	if !checkForEitherExampleOrEntryMd(files) {
+	if !checkForEitherExampleMdOrEntryMd(files) {
 		return fmt.Errorf("Expected to find either ENTRY.md or example.ENTRY.md in the executable directory, but found neither")
 	}
 

--- a/internal/stage_1.go
+++ b/internal/stage_1.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	chess_bot_executable "github.com/codecrafters-io/gleam-chess-bot-tester/internal/chess-bot-executable"
 	"github.com/codecrafters-io/gleam-chess-bot-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -13,6 +15,14 @@ func test1(stageHarness *test_case_harness.TestCaseHarness) error {
 	}
 
 	logger := stageHarness.Logger
+
+	files, err := listFilesInExecutableDir(stageHarness)
+	if err != nil {
+		return err
+	}
+	if !checkForEitherExampleOrEntryMd(files) {
+		return fmt.Errorf("Expected to find either ENTRY.md or example.ENTRY.md in the executable directory, but found neither")
+	}
 
 	// Opening position
 	FEN := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -20,7 +20,7 @@ func test5(stageHarness *test_case_harness.TestCaseHarness) error {
 		return err
 	}
 	if !checkForEntryMd(files) {
-		return fmt.Errorf("ENTRY.md not found")
+		return fmt.Errorf("ENTRY.md file not found, please make sure you rename the example.ENTRY.md file to ENTRY.md, and fill in the required fields to participate in the Gleam Chess Tournament.")
 	}
 	logger.Successf("ENTRY.md file found! You're all set to participate in the Gleam Chess Tournament.")
 

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -28,3 +28,40 @@ func test5(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	return nil
 }
+
+func checkForEntryMd(files []os.DirEntry) bool {
+	return checkForFile(files, "ENTRY.md")
+}
+
+func checkForExampleEntryMd(files []os.DirEntry) bool {
+	return checkForFile(files, "example.ENTRY.md")
+}
+
+func checkForEitherExampleOrEntryMd(files []os.DirEntry) bool {
+	return checkForExampleEntryMd(files) || checkForEntryMd(files)
+}
+
+func listFilesInExecutableDir(stageHarness *test_case_harness.TestCaseHarness) ([]os.DirEntry, error) {
+	executablePath := stageHarness.Executable.Path
+	executableDir := filepath.Dir(executablePath)
+
+	files, err := os.ReadDir(executableDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+func checkForFile(files []os.DirEntry, fileName string) bool {
+	if len(files) == 0 {
+		return false
+	}
+
+	for _, file := range files {
+		if file.Name() == fileName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -2,8 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	chess_bot_executable "github.com/codecrafters-io/gleam-chess-bot-tester/internal/chess-bot-executable"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
@@ -27,41 +25,4 @@ func test5(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger.Successf("ENTRY.md file found! You're all set to participate in the Gleam Chess Tournament.")
 
 	return nil
-}
-
-func checkForEntryMd(files []os.DirEntry) bool {
-	return checkForFile(files, "ENTRY.md")
-}
-
-func checkForExampleEntryMd(files []os.DirEntry) bool {
-	return checkForFile(files, "example.ENTRY.md")
-}
-
-func checkForEitherExampleOrEntryMd(files []os.DirEntry) bool {
-	return checkForExampleEntryMd(files) || checkForEntryMd(files)
-}
-
-func listFilesInExecutableDir(stageHarness *test_case_harness.TestCaseHarness) ([]os.DirEntry, error) {
-	executablePath := stageHarness.Executable.Path
-	executableDir := filepath.Dir(executablePath)
-
-	files, err := os.ReadDir(executableDir)
-	if err != nil {
-		return nil, err
-	}
-
-	return files, nil
-}
-
-func checkForFile(files []os.DirEntry, fileName string) bool {
-	if len(files) == 0 {
-		return false
-	}
-
-	for _, file := range files {
-		if file.Name() == fileName {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/stage_5.go
+++ b/internal/stage_5.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	chess_bot_executable "github.com/codecrafters-io/gleam-chess-bot-tester/internal/chess-bot-executable"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func test5(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := chess_bot_executable.NewChessBotExecutable(stageHarness)
+	if err := b.Run(); err != nil {
+		return err
+	}
+
+	logger := stageHarness.Logger
+
+	files, err := listFilesInExecutableDir(stageHarness)
+	if err != nil {
+		return err
+	}
+	if !checkForEntryMd(files) {
+		return fmt.Errorf("ENTRY.md not found")
+	}
+	logger.Successf("ENTRY.md file found! You're all set to participate in the Gleam Chess Tournament.")
+
+	return nil
+}

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -19,10 +19,17 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"invalid_move": {
-			UntilStageSlug:      "gd8",
+			UntilStageSlug:      "zz5",
 			CodePath:            "./test_helpers/scenarios/failure_bot",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/test_bot/failure",
+			NormalizeOutputFunc: normalizeTesterOutput,
+		},
+		"invalid_repo_state": {
+			StageSlugs:          []string{"si0"},
+			CodePath:            "./test_helpers/scenarios/failure_bot",
+			ExpectedExitCode:    1,
+			StdoutFixturePath:   "./test_helpers/fixtures/invalid_repo_state/failure",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 	}

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -12,14 +12,14 @@ func TestStages(t *testing.T) {
 
 	testCases := map[string]tester_utils_testing.TesterOutputTestCase{
 		"success": {
-			UntilStageSlug:      "zz5",
+			UntilStageSlug:      "gd8",
 			CodePath:            "./test_helpers/scenarios/test_bot",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/test_bot/success",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"invalid_move": {
-			UntilStageSlug:      "zz5",
+			UntilStageSlug:      "gd8",
 			CodePath:            "./test_helpers/scenarios/failure_bot",
 			ExpectedExitCode:    1,
 			StdoutFixturePath:   "./test_helpers/fixtures/test_bot/failure",

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -98,3 +98,4 @@ stages:
   - slug: "xt9"
   - slug: "wd4"
   - slug: "zz5"
+  - slug: "gd8"

--- a/internal/test_helpers/fixtures/invalid_repo_state/failure
+++ b/internal/test_helpers/fixtures/invalid_repo_state/failure
@@ -1,0 +1,8 @@
+Debug = true
+
+[33m[stage-1] [0m[94mRunning tests for Stage #1: si0[0m
+[33m[stage-1] [0m[94m$ ./your_program.sh[0m
+[33m[stage-1] [0m[91mExpected to find either ENTRY.md or example.ENTRY.md in the executable directory, but found neither[0m
+[33m[stage-1] [0m[91mTest failed[0m
+[33m[stage-1] [0m[36mTerminating program[0m
+[33m[stage-1] [0m[36mProgram terminated successfully[0m

--- a/internal/test_helpers/fixtures/test_bot/success
+++ b/internal/test_helpers/fixtures/test_bot/success
@@ -1,5 +1,12 @@
 Debug = true
 
+[33m[stage-5] [0m[94mRunning tests for Stage #5: gd8[0m
+[33m[stage-5] [0m[94m$ ./your_program.sh[0m
+[33m[stage-5] [0m[92mENTRY.md file found! You're all set to participate in the Gleam Chess Tournament.[0m
+[33m[stage-5] [0m[92mTest passed.[0m
+[33m[stage-5] [0m[36mTerminating program[0m
+[33m[stage-5] [0m[36mProgram terminated successfully[0m
+
 [33m[stage-4] [0m[94mRunning tests for Stage #4: zz5[0m
 [33m[stage-4] [0m[94m$ ./your_program.sh[0m
 [33m[stage-4] [board-1] [0m[94mPosition: 2r3k1/q4ppp/p3p3/pnNp4/2rP4/2P2P2/4R1PP/2R1Q1K1 b - - 0 1[0m

--- a/internal/test_helpers/scenarios/test_bot/ENTRY.md
+++ b/internal/test_helpers/scenarios/test_bot/ENTRY.md
@@ -1,0 +1,13 @@
+# Gleam Chess Tournament Submission
+
+## Participant Information
+- Email: [Your Email]
+- Name: [Your Name]
+
+### Git Repository URL
+- Repository URL: [Your Repo URL]
+(Should be a public repo with the code for the bot.)
+
+---
+
+*Note: Your name may be used in the video/stream at the end of the tournament, so provide something you're happy sharing with the world.*

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -37,5 +37,10 @@ var testerDefinition = tester_definition.TesterDefinition{
 			TestFunc: test4,
 			Timeout:  20 * time.Second,
 		},
+		{
+			Slug:     "gd8",
+			TestFunc: test5,
+			Timeout:  20 * time.Second,
+		},
 	},
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,12 +1,76 @@
 package internal
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 	"github.com/corentings/chess"
 )
+
+func makeMove(fenStr string) (string, error) {
+	fen, err := chess.FEN(fenStr)
+	if err != nil {
+		return "", err
+	}
+
+	game := chess.NewGame(fen)
+
+	// Determine turn color
+	turn := "white"
+	if game.Position().Turn() == chess.Black {
+		turn = "black"
+	}
+
+	// Prepare request body
+	type requestBody struct {
+		Fen         string   `json:"fen"`
+		Turn        string   `json:"turn"`
+		FailedMoves []string `json:"failed_moves"`
+	}
+
+	body := requestBody{
+		Fen:         fenStr,
+		Turn:        turn,
+		FailedMoves: []string{},
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling request body: %v", err)
+	}
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Post(
+		"http://localhost:8000/move",
+		"application/json",
+		bytes.NewBuffer(jsonBody),
+	)
+	if err != nil {
+		return "", fmt.Errorf("error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to make move, got status %d: %s", resp.StatusCode, string(responseBody))
+	}
+
+	return string(responseBody), nil
+}
 
 func checkFEN(FEN string) bool {
 	_, err := chess.FEN(FEN)
@@ -27,7 +91,7 @@ func checkForExampleEntryMd(files []os.DirEntry) bool {
 	return checkForFile(files, "example.ENTRY.md")
 }
 
-func checkForEitherExampleOrEntryMd(files []os.DirEntry) bool {
+func checkForEitherExampleMdOrEntryMd(files []os.DirEntry) bool {
 	return checkForExampleEntryMd(files) || checkForEntryMd(files)
 }
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,76 +1,12 @@
 package internal
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 	"github.com/corentings/chess"
 )
-
-func makeMove(fenStr string) (string, error) {
-	fen, err := chess.FEN(fenStr)
-	if err != nil {
-		return "", err
-	}
-
-	game := chess.NewGame(fen)
-
-	// Determine turn color
-	turn := "white"
-	if game.Position().Turn() == chess.Black {
-		turn = "black"
-	}
-
-	// Prepare request body
-	type requestBody struct {
-		Fen         string   `json:"fen"`
-		Turn        string   `json:"turn"`
-		FailedMoves []string `json:"failed_moves"`
-	}
-
-	body := requestBody{
-		Fen:         fenStr,
-		Turn:        turn,
-		FailedMoves: []string{},
-	}
-
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		return "", fmt.Errorf("error marshaling request body: %v", err)
-	}
-
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-	}
-
-	resp, err := client.Post(
-		"http://localhost:8000/move",
-		"application/json",
-		bytes.NewBuffer(jsonBody),
-	)
-	if err != nil {
-		return "", fmt.Errorf("error making request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("error reading response: %v", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to make move, got status %d: %s", resp.StatusCode, string(responseBody))
-	}
-
-	return string(responseBody), nil
-}
 
 func checkFEN(FEN string) bool {
 	_, err := chess.FEN(FEN)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
 	"github.com/corentings/chess"
 )
 
@@ -76,4 +79,43 @@ func checkFEN(FEN string) bool {
 		_, err = chess.FEN(FEN)
 	}
 	return err == nil
+}
+
+// File utils to check for the existence of entry files in the repo
+
+func checkForEntryMd(files []os.DirEntry) bool {
+	return checkForFile(files, "ENTRY.md")
+}
+
+func checkForExampleEntryMd(files []os.DirEntry) bool {
+	return checkForFile(files, "example.ENTRY.md")
+}
+
+func checkForEitherExampleOrEntryMd(files []os.DirEntry) bool {
+	return checkForExampleEntryMd(files) || checkForEntryMd(files)
+}
+
+func listFilesInExecutableDir(stageHarness *test_case_harness.TestCaseHarness) ([]os.DirEntry, error) {
+	executablePath := stageHarness.Executable.Path
+	executableDir := filepath.Dir(executablePath)
+
+	files, err := os.ReadDir(executableDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+func checkForFile(files []os.DirEntry, fileName string) bool {
+	if len(files) == 0 {
+		return false
+	}
+
+	for _, file := range files {
+		if file.Name() == fileName {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Introduce functionality to check for the presence of ENTRY.md or example.ENTRY.md files in the executable directory. Add a new stage for testing and provide an ENTRY.md template for Gleam Chess Tournament submissions. Update references in the Makefile and tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new stage for the Gleam Chess Tournament, requiring participants to submit an ENTRY.md file with their details.
  - Added validation to ensure ENTRY.md or example.ENTRY.md is present for tournament participation.
- **Bug Fixes**
  - Improved error messages when required markdown files are missing.
- **Tests**
  - Expanded test coverage with new scenarios and fixtures for the updated stage and file validation.
- **Documentation**
  - Added a template ENTRY.md file for tournament submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->