### PR TITLE
Enhance logging by using curl syntax for requests

### DIFF
--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -17,6 +17,8 @@ func test2(stageHarness *test_case_harness.TestCaseHarness) error {
 	// Opening position
 	FEN := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
+	logger.UpdateSecondaryPrefix("board")
+	stageHarness.Logger.Infof("Position: %s", FEN)
 	test_case := test_cases.GetMoveTestCase{
 		FEN:                        FEN,
 		AssertGeneratedMoveIsValid: true,
@@ -24,6 +26,7 @@ func test2(stageHarness *test_case_harness.TestCaseHarness) error {
 	if err := test_case.Run(stageHarness, logger); err != nil {
 		return err
 	}
+	logger.ResetSecondaryPrefix()
 
 	return nil
 }

--- a/internal/stage_2.go
+++ b/internal/stage_2.go
@@ -18,7 +18,7 @@ func test2(stageHarness *test_case_harness.TestCaseHarness) error {
 	FEN := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
 	logger.UpdateSecondaryPrefix("board")
-	stageHarness.Logger.Infof("Position: %s", FEN)
+	stageHarness.Logger.Infof("$ %s", getCurlCommandForRequest(FEN))
 	test_case := test_cases.GetMoveTestCase{
 		FEN:                        FEN,
 		AssertGeneratedMoveIsValid: true,

--- a/internal/stage_3.go
+++ b/internal/stage_3.go
@@ -29,7 +29,7 @@ func test3(stageHarness *test_case_harness.TestCaseHarness) error {
 			AssertGeneratedMoveIsValid: true,
 		}
 		logger.UpdateSecondaryPrefix(fmt.Sprintf("board-%d", i+1))
-		stageHarness.Logger.Infof("Position: %s", FEN)
+		stageHarness.Logger.Infof("$ %s", getCurlCommandForRequest(FEN))
 
 		if err := test_case.Run(stageHarness, logger); err != nil {
 			return err

--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -28,7 +28,7 @@ func test4(stageHarness *test_case_harness.TestCaseHarness) error {
 			AssertGeneratedMoveIsValid: true,
 		}
 		logger.UpdateSecondaryPrefix(fmt.Sprintf("board-%d", i+1))
-		stageHarness.Logger.Infof("Position: %s", FEN)
+		stageHarness.Logger.Infof("$ %s", getCurlCommandForRequest(FEN))
 
 		if err := testCase.Run(stageHarness, logger); err != nil {
 			return err

--- a/internal/test_cases/get_move_test_case.go
+++ b/internal/test_cases/get_move_test_case.go
@@ -24,7 +24,7 @@ type GetMoveTestCase struct {
 
 // For invalid FENs, we still need to parse the turn
 // Parsing FENs is a no-go for those test cases
-func getTurn(fenStr string) string {
+func GetTurnFromFEN(fenStr string) string {
 	parts := strings.Split(fenStr, " ")
 	turn := strings.TrimSpace(parts[1])
 	if turn == "w" {
@@ -36,7 +36,7 @@ func getTurn(fenStr string) string {
 func (tc *GetMoveTestCase) Run(stageHarness *test_case_harness.TestCaseHarness, logger *logger.Logger) error {
 	requestBody := map[string]any{
 		"fen":          tc.FEN,
-		"turn":         getTurn(tc.FEN),
+		"turn":         GetTurnFromFEN(tc.FEN),
 		"failed_moves": []string{},
 	}
 	jsonBody, err := json.Marshal(requestBody)

--- a/internal/test_helpers/fixtures/test_bot/failure
+++ b/internal/test_helpers/fixtures/test_bot/failure
@@ -2,7 +2,7 @@ Debug = true
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: zz5[0m
 [33m[stage-4] [0m[94m$ ./your_program.sh[0m
-[33m[stage-4] [board-1] [0m[94mPosition: 2r3k1/q4ppp/p3p3/pnNp4/2rP4/2P2P2/4R1PP/2R1Q1K1 b - - 0 1[0m
+[33m[stage-4] [board-1] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"2r3k1/q4ppp/p3p3/pnNp4/2rP4/2P2P2/4R1PP/2R1Q1K1 b - - 0 1","turn":"black"}'[0m
 [33m[stage-4] [board-1] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-4] [board-1] [0m[92m✓ Received status code 200[0m
 [33m[stage-4] [board-1] [0m[91mAssertion failed: Invalid move received: e9e10[0m

--- a/internal/test_helpers/fixtures/test_bot/success
+++ b/internal/test_helpers/fixtures/test_bot/success
@@ -9,25 +9,25 @@ Debug = true
 
 [33m[stage-4] [0m[94mRunning tests for Stage #4: zz5[0m
 [33m[stage-4] [0m[94m$ ./your_program.sh[0m
-[33m[stage-4] [board-1] [0m[94mPosition: 2r3k1/q4ppp/p3p3/pnNp4/2rP4/2P2P2/4R1PP/2R1Q1K1 b - - 0 1[0m
+[33m[stage-4] [board-1] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"2r3k1/q4ppp/p3p3/pnNp4/2rP4/2P2P2/4R1PP/2R1Q1K1 b - - 0 1","turn":"black"}'[0m
 [33m[stage-4] [board-1] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-4] [board-1] [0m[92m✓ Received status code 200[0m
 [33m[stage-4] [board-1] [0m[92m✓ Received valid move g8f8[0m
 [33m[stage-4] [board-1] [0m[36mRequest completed successfully[0m
 [33m[stage-4] [0m[92mSuccessfully generated move for position 1[0m
-[33m[stage-4] [board-2] [0m[94mPosition: r5k1/1q4pp/2p5/p1Q5/2P5/5R2/4RKPP/r7 w - - 0 1[0m
+[33m[stage-4] [board-2] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"r5k1/1q4pp/2p5/p1Q5/2P5/5R2/4RKPP/r7 w - - 0 1","turn":"white"}'[0m
 [33m[stage-4] [board-2] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-4] [board-2] [0m[92m✓ Received status code 200[0m
 [33m[stage-4] [board-2] [0m[92m✓ Received valid move f2e3[0m
 [33m[stage-4] [board-2] [0m[36mRequest completed successfully[0m
 [33m[stage-4] [0m[92mSuccessfully generated move for position 2[0m
-[33m[stage-4] [board-3] [0m[94mPosition: 6k1/6p1/p7/3Pn3/5p2/4rBqP/P4RP1/5QK1 b - - 0 1[0m
+[33m[stage-4] [board-3] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"6k1/6p1/p7/3Pn3/5p2/4rBqP/P4RP1/5QK1 b - - 0 1","turn":"black"}'[0m
 [33m[stage-4] [board-3] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-4] [board-3] [0m[92m✓ Received status code 200[0m
 [33m[stage-4] [board-3] [0m[92m✓ Received valid move g8f7[0m
 [33m[stage-4] [board-3] [0m[36mRequest completed successfully[0m
 [33m[stage-4] [0m[92mSuccessfully generated move for position 3[0m
-[33m[stage-4] [board-4] [0m[94mPosition: r1b2rk1/ppbn1ppp/4p3/1QP4q/3P4/N4N2/5PPP/R1B2RK1 w - - 0 1[0m
+[33m[stage-4] [board-4] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"r1b2rk1/ppbn1ppp/4p3/1QP4q/3P4/N4N2/5PPP/R1B2RK1 w - - 0 1","turn":"white"}'[0m
 [33m[stage-4] [board-4] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-4] [board-4] [0m[92m✓ Received status code 200[0m
 [33m[stage-4] [board-4] [0m[92m✓ Received valid move g1h1[0m
@@ -39,19 +39,19 @@ Debug = true
 
 [33m[stage-3] [0m[94mRunning tests for Stage #3: wd4[0m
 [33m[stage-3] [0m[94m$ ./your_program.sh[0m
-[33m[stage-3] [board-1] [0m[94mPosition: r3r1k1/ppqb1ppp/8/4p1NQ/8/2P5/PP3PPP/R3R1K1 b - -[0m
+[33m[stage-3] [board-1] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"r3r1k1/ppqb1ppp/8/4p1NQ/8/2P5/PP3PPP/R3R1K1 b - -","turn":"black"}'[0m
 [33m[stage-3] [board-1] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-3] [board-1] [0m[92m✓ Received status code 200[0m
 [33m[stage-3] [board-1] [0m[92m✓ Received valid move g8f8[0m
 [33m[stage-3] [board-1] [0m[36mRequest completed successfully[0m
 [33m[stage-3] [0m[92mSuccessfully generated move for position 1[0m
-[33m[stage-3] [board-2] [0m[94mPosition: 3r1k2/4npp1/1ppr3p/p6P/P2PPPP1/1NR5/5K2/2R5 w - -[0m
+[33m[stage-3] [board-2] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"3r1k2/4npp1/1ppr3p/p6P/P2PPPP1/1NR5/5K2/2R5 w - -","turn":"white"}'[0m
 [33m[stage-3] [board-2] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-3] [board-2] [0m[92m✓ Received status code 200[0m
 [33m[stage-3] [board-2] [0m[92m✓ Received valid move f2e1[0m
 [33m[stage-3] [board-2] [0m[36mRequest completed successfully[0m
 [33m[stage-3] [0m[92mSuccessfully generated move for position 2[0m
-[33m[stage-3] [board-3] [0m[94mPosition: 1nk1r1r1/pp2n1pp/4p3/q2pPp1N/b1pP1P2/B1P2R2/2P1B1PP/R2Q2K1 w - -[0m
+[33m[stage-3] [board-3] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"1nk1r1r1/pp2n1pp/4p3/q2pPp1N/b1pP1P2/B1P2R2/2P1B1PP/R2Q2K1 w - -","turn":"white"}'[0m
 [33m[stage-3] [board-3] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
 [33m[stage-3] [board-3] [0m[92m✓ Received status code 200[0m
 [33m[stage-3] [board-3] [0m[92m✓ Received valid move g1f1[0m
@@ -63,10 +63,11 @@ Debug = true
 
 [33m[stage-2] [0m[94mRunning tests for Stage #2: xt9[0m
 [33m[stage-2] [0m[94m$ ./your_program.sh[0m
-[33m[stage-2] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
-[33m[stage-2] [0m[92m✓ Received status code 200[0m
-[33m[stage-2] [0m[92m✓ Received valid move b1a3[0m
-[33m[stage-2] [0m[36mRequest completed successfully[0m
+[33m[stage-2] [board] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1","turn":"white"}'[0m
+[33m[stage-2] [board] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
+[33m[stage-2] [board] [0m[92m✓ Received status code 200[0m
+[33m[stage-2] [board] [0m[92m✓ Received valid move b1a3[0m
+[33m[stage-2] [board] [0m[36mRequest completed successfully[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 [33m[stage-2] [0m[36mTerminating program[0m
 [33m[stage-2] [0m[36mProgram terminated successfully[0m

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,12 +1,22 @@
 package internal
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/codecrafters-io/gleam-chess-bot-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 	"github.com/corentings/chess"
 )
+
+func getCurlCommandForRequest(FEN string) string {
+	// Request type: POST
+	// URL: http://localhost:8080/move
+	// Headers: Content-Type: application/json
+	// Body: {"failed_moves": [], "fen": FEN, "turn": "white"|"black"}
+	return fmt.Sprintf(`curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"%s","turn":"%s"}'`, FEN, test_cases.GetTurnFromFEN(FEN))
+}
 
 func checkFEN(FEN string) bool {
 	_, err := chess.FEN(FEN)


### PR DESCRIPTION
Improve logging in test functions to include curl commands for FEN requests and rename the `getTurn` function for better clarity. Additionally, add a new function to generate curl commands for FEN requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging to show curl command representations of chess board positions for better traceability.
- **Refactor**
  - Renamed a function for clarity and made it publicly accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->