### PR TITLE
fix: reduce stage 4 test count to avoid 20s timeout

### DIFF
--- a/internal/stage_4.go
+++ b/internal/stage_4.go
@@ -17,7 +17,7 @@ func test4(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	positionCounts := 4
+	positionCounts := 3
 	for i, FEN := range random.RandomElementsFromArray(WinAtChessFENs, positionCounts) {
 		if !checkFEN(FEN) {
 			continue

--- a/internal/test_helpers/fixtures/test_bot/success
+++ b/internal/test_helpers/fixtures/test_bot/success
@@ -27,12 +27,6 @@ Debug = true
 [33m[stage-4] [board-3] [0m[92m✓ Received valid move g8f7[0m
 [33m[stage-4] [board-3] [0m[36mRequest completed successfully[0m
 [33m[stage-4] [0m[92mSuccessfully generated move for position 3[0m
-[33m[stage-4] [board-4] [0m[94m$ curl -X POST http://localhost:8000/move -H "Content-Type: application/json" -d '{"failed_moves":[],"fen":"r1b2rk1/ppbn1ppp/4p3/1QP4q/3P4/N4N2/5PPP/R1B2RK1 w - - 0 1","turn":"white"}'[0m
-[33m[stage-4] [board-4] [0m[36mMaking HTTP request to http://localhost:8000/move[0m
-[33m[stage-4] [board-4] [0m[92m✓ Received status code 200[0m
-[33m[stage-4] [board-4] [0m[92m✓ Received valid move g1h1[0m
-[33m[stage-4] [board-4] [0m[36mRequest completed successfully[0m
-[33m[stage-4] [0m[92mSuccessfully generated move for position 4[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 [33m[stage-4] [0m[36mTerminating program[0m
 [33m[stage-4] [0m[36mProgram terminated successfully[0m


### PR DESCRIPTION
Some folks are running into issues with stage 4 because they have their bots set up to spend _exactly_ 5 seconds searching for moves, and the timeout doesn't take into account setup time etc.